### PR TITLE
Closes #4: Callback is called when pagination is created

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,8 @@ ellipse_text
 	displayed number interval, this text will be inserted into the gap (inside a
 	span tag). Can be left blank to avoid the additional tag. Default: ``...``
 
+load_first_page
+	If true (default) then the first page will be loaded automatically.
 
 Triggering pagination with custom events
 ----------------------------------------

--- a/src/jquery.pagination.js
+++ b/src/jquery.pagination.js
@@ -142,6 +142,7 @@
 			prev_show_always:true,
 			next_show_always:true,
 			renderer:"defaultRenderer",
+			load_first_page:false,
 			callback:function(){return false;}
 		},opts||{});
 		
@@ -222,7 +223,9 @@
 		containers.empty();
 		links.appendTo(containers);
 		// call callback function
-		opts.callback(current_page, containers);
+		if(opts.load_first_page) {
+			opts.callback(current_page, containers);
+		}
 	} // End of $.fn.pagination block
 	
 })(jQuery);


### PR DESCRIPTION
Hi Gabriel,

Firstly thanks for jquery_pagination - I'm using it in my jquery-tumblr plugin.

I've committed a patch to close issue #4 - https://github.com/gbirke/jquery_pagination/issues/4

Basically I've added an option, called load_first_page which disables loading the first page on initialisation. This way not backwards compatibility will be broken.

Cheers,
Alex
