### PR TITLE
Broken next Page button when current_page is String

### DIFF
--- a/src/jquery.pagination.js
+++ b/src/jquery.pagination.js
@@ -183,7 +183,7 @@
 		// -----------------------------------
 		// Initialize containers
 		// -----------------------------------
-		current_page = opts.current_page;
+                current_page = parseInt(opts.current_page);
 		containers.data('current_page', current_page);
 		// Create a sane value for maxentries and items_per_page
 		maxentries = (!maxentries || maxentries < 0)?1:maxentries;


### PR DESCRIPTION
At the moment if you pass in current_page as a String and click the next Page button it will concatenate 
current_page, so you will jump from page 1 to page 11
added parseInt() to fix this.
