### PR TITLE
Disable the pagination if there its only one page (by default)

### DIFF
--- a/src/demo/demo_singlePage.htm
+++ b/src/demo/demo_singlePage.htm
@@ -1,0 +1,81 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <title>Pagination Demo I - Simple pagination</title>
+        <link rel="stylesheet" href="../pagination.css" />
+        <link rel="stylesheet" href="demo.css" />
+        <script type="text/javascript" src="lib/jquery.min.js"></script>
+        <script type="text/javascript" src="../jquery.pagination.js"></script>
+        
+        <script type="text/javascript">
+        
+            // This is a very simple demo that showing the options for handling a single page.
+            // Default of the option show_if_single_page is false.
+            // So you only have to call the plugin with this option if you feel the need
+            // to show the pagination even if there is only one single page.
+            // Otherwise just leave it out.
+        
+            /**
+             * Callback function that displays the content.
+             *
+             * Gets called every time the user clicks on a pagination link.
+             *
+             * @param {int} page_index New Page index
+             * @param {jQuery} jq the container with the pagination links as a jQuery object
+             */
+            function pageselectCallback(page_index, jq){
+                var new_content = jQuery('#hiddenresult div.result:eq('+page_index+')').clone();
+                $('#Searchresult').empty().append(new_content);
+                return false;
+            }
+           
+            /** 
+             * Initialisation function for pagination
+             */
+            function initPagination() {
+                // count entries inside the hidden content
+                var num_entries = jQuery('#hiddenresult div.result').length;
+                // Create content inside pagination element
+                $("#Pagination").pagination(num_entries, {
+                    callback: pageselectCallback,
+                    items_per_page:1, // Show only one item per page
+                    //show_if_single_page:true // Show if there is only one single page
+                });
+             }
+            
+            // When document is ready, initialize pagination
+            $(document).ready(function(){      
+                initPagination();
+            });
+            
+            
+            
+        </script>
+    </head>
+    <body>
+        <h1>jQuery Pagination Plugin Demo</h1>
+        
+        <h2>Show Pagination if there is only one single page</h2>
+        <div id="Pagination"></div>
+        <div id="Searchresult" style="clear:both;">
+            <p>Page 1</p>
+        </div>
+        
+        <!-- Container element for all the Elements that are to be paginated -->
+        <div id="hiddenresult" style="display:none;">
+            <div class="result">
+            	<p>Page 1</p>
+            </div>
+            <!--
+            <div class="result">
+            	<p>Page 2</p>
+            </div>
+            -->
+        </div>
+        
+        <div id="footer">
+            Copyright &copy; 2010 by <a href="http://www.d-scribe.de/">describe europe Ltd.</a>.
+        </div>
+    </body>
+</html>

--- a/src/jquery.pagination.js
+++ b/src/jquery.pagination.js
@@ -142,6 +142,7 @@
 			prev_show_always:true,
 			next_show_always:true,
 			renderer:"defaultRenderer",
+			show_if_single_page:false,
 			load_first_page:false,
 			callback:function(){return false;}
 		},opts||{});
@@ -221,7 +222,9 @@
 		// When all initialisation is done, draw the links
 		links = renderer.getLinks(current_page, paginationClickHandler);
 		containers.empty();
-		links.appendTo(containers);
+		if(np > 1 || opts.show_if_single_page) {
+			links.appendTo(containers);
+		}
 		// call callback function
 		if(opts.load_first_page) {
 			opts.callback(current_page, containers);


### PR DESCRIPTION
[+FEATURE] New option »show_if_single_page« from @draken as decribed here: https://github.com/gbirke/jquery_pagination/pull/2
[+FEATURE] Demo page for option »show_if_single_page«
